### PR TITLE
21 feature add color wheel

### DIFF
--- a/Lantern.cpp
+++ b/Lantern.cpp
@@ -56,3 +56,16 @@ static void Lantern::wait(float seconds) {
 
   delay(int(seconds * 1000));
 }
+
+uint32_t Lantern::colorWheel(uint8_t WheelPos) {
+  WheelPos = 255 - WheelPos;
+  if(WheelPos < 85) {
+    return _pixels.Color(255 - WheelPos * 3, 0, WheelPos * 3);
+  }
+  if(WheelPos < 170) {
+    WheelPos -= 85;
+    return _pixels.Color(0, WheelPos * 3, 255 - WheelPos * 3);
+  }
+  WheelPos -= 170;
+  return _pixels.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
+}

--- a/Lantern.h
+++ b/Lantern.h
@@ -88,6 +88,17 @@ class Lantern {
      */
     static void wait(float seconds);
 
+    /**
+     * @brief Get the color of the rainbow at a certain point. Allows us to 
+     * insert any number and get a valid color. Useful in tangent with noise or
+     * random functions. Implementation borrowed from Adafruit's NeoPixel 
+     * example code. https://github.com/adafruit/Adafruit_NeoPixel/
+     * 
+     * @param wheelPos 
+     * @return uint32_t 
+     */
+    uint32_t colorWheel(uint8_t);
+
   private:
     int _pin;
     int _numPixels;

--- a/examples/colorWheel/colorWheel.ino
+++ b/examples/colorWheel/colorWheel.ino
@@ -20,7 +20,8 @@ void setup() {
  */
 void loop() {
   // checkLight();
-  rainbowWheel();
+  // rainbowWheel();
+  checkLightWheelBig();
 }
 
 /**
@@ -37,7 +38,7 @@ void checkLight() {
   int blue = 0;
   float seconds = 0.5;
 
-  lantern.setColor(seconds, lantern.setColor(red, green, blue));
+  lantern.setColor(seconds, lantern.color(red, green, blue));
 }
 
 /**
@@ -63,4 +64,11 @@ void rainbowWheel() {
   for (int i = 0; i < 255; i++) {
     lantern.setColor(0.1, lantern.colorWheel(i));
   }
+}
+
+void checkLightWheelBig() {
+  float seconds = 0.5;
+
+  lantern.setColor(seconds, lantern.colorWheel(-500));
+  lantern.setColor(seconds, lantern.colorWheel(500));
 }

--- a/examples/colorWheel/colorWheel.ino
+++ b/examples/colorWheel/colorWheel.ino
@@ -1,0 +1,66 @@
+/**
+ * Activity 1: Get those lights on!
+ * 
+ */
+#include <Lantern.h>
+
+Lantern lantern;
+
+/**
+ * @brief This function only runs once to "setup" the Lantern.
+ * 
+ */
+void setup() {
+  lantern.begin();
+}
+
+/**
+ * @brief This function repeats itself, like a loop!
+ * 
+ */
+void loop() {
+  // checkLight();
+  rainbowWheel();
+}
+
+/**
+ * @brief Sets color values for our lantern. Used to check if our Lantern is 
+ * ready to accept instructions.
+ * 
+ * Not getting the color you want? Check out this website to learn how to pick
+ * your color using just Red, Green, and Blue!
+ * - [RGB Color Picker](https://www.w3schools.com/colors/colors_rgb.asp)
+ */
+void checkLight() {
+  int red = 0;
+  int green = 150;
+  int blue = 0;
+  float seconds = 0.5;
+
+  lantern.setColor(seconds, lantern.colorWheel(32));
+}
+
+/**
+ * @brief Sets color values for our lantern. Used to check if our lantern is
+ * ready to accept instructions.
+ * 
+ * Instead of using 3 numbers, we can just a single number! This allows us
+ * to grab a color from the rainbow if the rainbow was a line from 0-255 
+ * starting at red, then going to green, then blue, the finally back to red.
+ * 
+ */
+void checkLightWheel() {
+  // Try changing the number to any other number you want!
+  lantern.setColor(0.5, lantern.colorWheel(0));
+}
+
+/**
+ * @brief Sets the color values for our lantern. Goes through all the colors
+ * of the rainbow this time!
+ * 
+ */
+void rainbowWheel() {
+  for (int i = 0; i < 255; i++) {
+    lantern.setColor(0.1, lantern.colorWheel(i));
+  }
+}

--- a/examples/colorWheel/colorWheel.ino
+++ b/examples/colorWheel/colorWheel.ino
@@ -66,6 +66,11 @@ void rainbowWheel() {
   }
 }
 
+/**
+ * @brief Sets the color values for our lantern. Demonstrates that any number
+ * fits in the color wheel.
+ * 
+ */
 void checkLightWheelBig() {
   float seconds = 0.5;
 

--- a/examples/colorWheel/colorWheel.ino
+++ b/examples/colorWheel/colorWheel.ino
@@ -37,7 +37,7 @@ void checkLight() {
   int blue = 0;
   float seconds = 0.5;
 
-  lantern.setColor(seconds, lantern.colorWheel(32));
+  lantern.setColor(seconds, lantern.setColor(red, green, blue));
 }
 
 /**

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,6 +14,7 @@ begin       KEYWORD2
 color       KEYWORD2
 setColor    KEYWORD2
 wait        KEYWORD2
+colorWheel  KEYWORD2
 
 ######################################
 # Constants

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CC-Lantern
-version=1.1.0
+version=1.2.0
 author=Code With Her
 maintainer=Ryan <ryan@codewithher.org>
 sentence=Arduino library for controlling single-wire-based LED pixels and strip.


### PR DESCRIPTION
**Why:**
We've been needing easier access to a color wheel in the library. This PR adds a new example file demonstrating the difference between the rgb and the wheel methods.

Closes the following issues (all PRs must close an issue):

- closes #24 

**What's being changed**
Adds a new function, `colorWheel()` which allows users to use a single number to generate a color. This is useful for noise functions or other similar randomness functions to produce a color.

Technically in #22 we already have a `colorWheel` implementation but that implementation is not at the library level. The example does not demonstrate how it is implemented, only its usage. There is still merit in maintaining the existing act3-functions around implementing the colorWheel as a rainbow() function instead. Additionally, the `rainbow()` function actually allows the user to set the amount of time that the rainbow pattern as a whole runs for while the `colorWheel` only returns a `uint32_t` / color value.

**Testing Instructions**

> Describe the ways to test it and any relevant information. 

Note: the input for colorwheel is a `uint8_t` which has an unsigned integer range of 0-255. Any values outside of that range get modulo looped. Thus edge tests do not need to be larger than 256 or less than 0.

- Edge tests
  - negative: `-50`
  - negative large number: `-500`
  - positive: `50`
  - positive large number: `1000`
- Wheel test
  - should loop through a rainbow of colors from red -> green -> blue

1. Using numbers to demonstrate the order of actions to take is great

**Check off the following**

- [x] I have tested my changes locally
- [x] I have incremented the version number in the [library.properties](/library.properties) file [^1]

[^1]: See [CONTRIBUTING.md](/CONTRIBUTING.md) for more information on version semantics